### PR TITLE
GEN-3787 ci: add GitHub Action to publish Docker image on PR merge

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Publish Docker Image on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-and-push:
+    # Hanya berjalan jika PR ditutup karena di-merge
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Configure git to use HTTPS instead of SSH
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          submodules: 'recursive'
+          fetch-depth: 0
+          token: ${{ secrets.WUKONG_PAT }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Mendapatkan commit hash pendek
+      - name: Get short git commit SHA
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./staging.dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/black-hole:${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
#### **Overview**
This PR adds the GitHub Actions workflow (`docker-publish.yml`) to automate building and pushing Docker images to Docker Hub upon Pull Request merge to targeted branches.

#### **Changes**
- Added `.github/workflows/docker-publish.yml`.
- Configured trigger on PR closed and merged to `main` and `develop` branches.
- Set up target Dockerfile build context using `./staging.dockerfile` (matching the staging configuration).
- Configured automatic tagging with the short git commit SHA.
- Added submodule checkout support via `secrets.WUKONG_PAT`.

#### **Pre-requisites**
Make sure the following secrets are configured in the repository settings:
- `DOCKERHUB_USERNAME` - Your Docker Hub username.
- `DOCKERHUB_TOKEN` - Your Docker Hub access token.
- `WUKONG_PAT` - Personal Access Token for checking out private submodules.

#### **Verification / Testing**
1. Merge this PR into `develop` or `main`.
2. Check the **Actions** tab on GitHub to verify if the "Publish Docker Image on PR Merge" workflow runs successfully.
3. Verify that the built image appears in the Docker Hub registry with the format: `<DOCKERHUB_USERNAME>/<repo-name>:<short-sha>`.