### PR TITLE
GEN-3947: allow the GCS image host

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -48,6 +48,12 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'wukong-production-public.s3.ap-southeast-3.amazonaws.com',
+      },
+      // GCS (GEN-3947). One host covers every bucket, and assets arrive as V4
+      // signed URLs so the query string carries a per-response signature.
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
       }
     ],
     formats: ['image/webp', 'image/avif']

--- a/next.config.js
+++ b/next.config.js
@@ -50,10 +50,13 @@ const nextConfig = {
         hostname: 'wukong-production-public.s3.ap-southeast-3.amazonaws.com',
       },
       // GCS (GEN-3947). One host covers every bucket, and assets arrive as V4
-      // signed URLs so the query string carries a per-response signature.
+      // signed URLs so the query string carries a per-response signature. The
+      // path is pinned to our buckets: the host alone would turn /_next/image
+      // into an optimizer for every public bucket on GCS.
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com',
+        pathname: '/wukong-*/**',
       }
     ],
     formats: ['image/webp', 'image/avif']

--- a/next.config.test.js
+++ b/next.config.test.js
@@ -12,6 +12,15 @@ describe('next.config images', () => {
     expect(hostnames).toContain('storage.googleapis.com');
   });
 
+  // Without a path, /_next/image would happily optimize any public bucket on
+  // GCS on someone else's behalf.
+  it('pins the GCS host to our buckets', () => {
+    const gcs = nextConfig.images.remotePatterns.find(
+      (pattern) => pattern.hostname === 'storage.googleapis.com'
+    );
+    expect(gcs.pathname).toBe('/wukong-*/**');
+  });
+
   it('still allows the S3 asset hosts until the production cutover is done', () => {
     expect(hostnames).toContain(
       'wukong-production-public.s3.ap-southeast-3.amazonaws.com'

--- a/next.config.test.js
+++ b/next.config.test.js
@@ -1,0 +1,20 @@
+const nextConfig = require('./next.config');
+
+// next/image rejects any host that is not whitelisted here, and it fails at
+// runtime only — a build and the whole test suite stay green while every asset
+// image 400s in production.
+describe('next.config images', () => {
+  const hostnames = nextConfig.images.remotePatterns.map(
+    (pattern) => pattern.hostname
+  );
+
+  it('allows the GCS asset host', () => {
+    expect(hostnames).toContain('storage.googleapis.com');
+  });
+
+  it('still allows the S3 asset hosts until the production cutover is done', () => {
+    expect(hostnames).toContain(
+      'wukong-production-public.s3.ap-southeast-3.amazonaws.com'
+    );
+  });
+});


### PR DESCRIPTION
### **User description**
## What

- Whitelist `storage.googleapis.com` in `images.remotePatterns`. Assets now arrive as signed GCS URLs, and next/image rejects any host that is not listed — at runtime only, so nothing else catches it.
- Add a small test over the host list so it cannot quietly go missing.

The four S3 hosts stay until the production cutover is done.

## Test

- `npm run build`: clean.
- `npm test`: our new suite passes. The suite as a whole is already red on `develop` — 5 to 7 suites fail depending on the run (`services/events`, `TimeField`, `finance/analytic`, `additional-form`, `reset-password/form`), some of them flaky. Untouched here, worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Whitelist GCS host in Next.js config.

- Add tests to validate remote image patterns.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Config
    next.config.js["next.config.js"]
  end
  subgraph Tests
    next.config.test.js["next.config.test.js"]
  end
  next.config.js -- "defines remotePatterns" --> next.config.test.js
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.js</strong><dd><code>Add GCS to allowed image hostnames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.js

<ul><li>Added <code>storage.googleapis.com</code> to the <code>images.remotePatterns</code> array to <br>allow loading assets from Google Cloud Storage.</ul>


</details>


  </td>
  <td><a href="https://github.com/Liku-id/black-hole/pull/276/files#diff-882b2c04b01b2e8b2cdcf1817c30ea503a8005f1c0d54cfff37053b6801fea85">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.test.js</strong><dd><code>Add tests for image remote patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.test.js

<ul><li>Created a new test suite to verify that <code>storage.googleapis.com</code> and S3 <br>production hosts are present in the Next.js image remote patterns.</ul>


</details>


  </td>
  <td><a href="https://github.com/Liku-id/black-hole/pull/276/files#diff-c6f77d662d4665be54942e909c6101ce749b8b88283af7de1f12d2accdb8b535">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

