### PR TITLE
release: allow & pin GCS asset host (GEN-3947)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -48,6 +48,12 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'wukong-production-public.s3.ap-southeast-3.amazonaws.com',
+      },
+      // GCS (GEN-3947). One host covers every bucket, and assets arrive as V4
+      // signed URLs so the query string carries a per-response signature.
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
       }
     ],
     formats: ['image/webp', 'image/avif']

--- a/next.config.js
+++ b/next.config.js
@@ -50,10 +50,13 @@ const nextConfig = {
         hostname: 'wukong-production-public.s3.ap-southeast-3.amazonaws.com',
       },
       // GCS (GEN-3947). One host covers every bucket, and assets arrive as V4
-      // signed URLs so the query string carries a per-response signature.
+      // signed URLs so the query string carries a per-response signature. The
+      // path is pinned to our buckets: the host alone would turn /_next/image
+      // into an optimizer for every public bucket on GCS.
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com',
+        pathname: '/wukong-*/**',
       }
     ],
     formats: ['image/webp', 'image/avif']

--- a/next.config.test.js
+++ b/next.config.test.js
@@ -12,6 +12,15 @@ describe('next.config images', () => {
     expect(hostnames).toContain('storage.googleapis.com');
   });
 
+  // Without a path, /_next/image would happily optimize any public bucket on
+  // GCS on someone else's behalf.
+  it('pins the GCS host to our buckets', () => {
+    const gcs = nextConfig.images.remotePatterns.find(
+      (pattern) => pattern.hostname === 'storage.googleapis.com'
+    );
+    expect(gcs.pathname).toBe('/wukong-*/**');
+  });
+
   it('still allows the S3 asset hosts until the production cutover is done', () => {
     expect(hostnames).toContain(
       'wukong-production-public.s3.ap-southeast-3.amazonaws.com'

--- a/next.config.test.js
+++ b/next.config.test.js
@@ -1,0 +1,20 @@
+const nextConfig = require('./next.config');
+
+// next/image rejects any host that is not whitelisted here, and it fails at
+// runtime only — a build and the whole test suite stay green while every asset
+// image 400s in production.
+describe('next.config images', () => {
+  const hostnames = nextConfig.images.remotePatterns.map(
+    (pattern) => pattern.hostname
+  );
+
+  it('allows the GCS asset host', () => {
+    expect(hostnames).toContain('storage.googleapis.com');
+  });
+
+  it('still allows the S3 asset hosts until the production cutover is done', () => {
+    expect(hostnames).toContain(
+      'wukong-production-public.s3.ap-southeast-3.amazonaws.com'
+    );
+  });
+});


### PR DESCRIPTION
### **User description**
## What

Release branch untuk production, cherry-pick dari `GEN-3947-storage-migration` (PR #276, sudah merged):

- `edb03f0` — GEN-3947: allow the GCS image host
- `cd8dc8b` — GEN-3947: pin the GCS host to our buckets

Backend (`third-party-service`) sekarang balikin asset URL sebagai signed `storage.googleapis.com` URL, bukan `*.s3.ap-southeast-3.amazonaws.com` lagi. `next/image` nolak host yang nggak ada di `remotePatterns` (fail di runtime, bukan build-time), jadi ini wajib jalan **sebelum** backend cutover ke `main`, kalau nggak semua gambar asset 400.

Path di-pin ke `/wukong-*/**` (bukan cuma hostname) supaya `/_next/image` nggak jadi image-optimizer gratis buat bucket publik siapapun di GCS.

Host S3 lama masih dibiarkan di `remotePatterns` sampai cutover production selesai (ada test yang secara eksplisit ngejaga itu).

Terkait: `Liku-id/third-party-service#165`, `Liku-id/black-void#280`.

## Verifikasi

- `next.config.test.js` (3 test baru: allow GCS host, pin path ke bucket kita, S3 host masih diizinkan sementara) — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Whitelist GCS host in Next.js config.

- Pin GCS path to specific buckets.

- Add tests for remote image patterns.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  config["next.config.js"] -- "defines remotePatterns" --> tests["next.config.test.js"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.js</strong><dd><code>Add GCS to allowed image remote patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.js

<ul><li>Added <code>storage.googleapis.com</code> to the <code>images.remotePatterns</code> array.<br> <li> Pinned the GCS pathname to <code>/wukong-*/**</code> to restrict image optimization <br>to specific buckets.</ul>


</details>


  </td>
  <td><a href="https://github.com/Liku-id/black-hole/pull/281/files#diff-882b2c04b01b2e8b2cdcf1817c30ea503a8005f1c0d54cfff37053b6801fea85">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.test.js</strong><dd><code>Add tests for image remote patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.test.js

<ul><li>Created a new test suite to validate Next.js image remote patterns.<br> <li> Added tests to verify GCS host whitelisting and path pinning.<br> <li> Ensured S3 production hosts remain allowed during the transition.</ul>


</details>


  </td>
  <td><a href="https://github.com/Liku-id/black-hole/pull/281/files#diff-c6f77d662d4665be54942e909c6101ce749b8b88283af7de1f12d2accdb8b535">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

